### PR TITLE
Add GitHub URL to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,14 @@ with open("README.rst", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-     name='ansible-ssh',  
+     name='ansible-ssh',
      version='0.9',
      scripts=['ansible-ssh'] ,
      author="Dimos Alevizos",
      author_email="dimos@alevizos.gr",
      description="Interactive SSH for Ansible",
      long_description=long_description,
+     url="https://github.com/dalevizo/ansible-ssh",
      packages=setuptools.find_packages(),
      classifiers=[
          "Programming Language :: Python :: 3",


### PR DESCRIPTION
This patch adds the GitHub URL to `setup.py`. If I understand correctly, this will add a GitHub link to PyPI as well, making the GitHub project easier to find.