### PR TITLE
Fix vault vars parsing for new python

### DIFF
--- a/ansible-ssh
+++ b/ansible-ssh
@@ -1,8 +1,9 @@
-#!/usr/bin/env python3
+#!/Users/mkartson/ansible_venv/bin/python3
 import subprocess
 import sys
 import yaml
 import os
+from ansible.parsing.utils.yaml import from_yaml
 from argparse import ArgumentParser
 
 parser = ArgumentParser()
@@ -55,7 +56,7 @@ with open(os.devnull, 'w') as devnull:
 for line in inventory.splitlines():
     if 'WARNING' not in line and 'deprecation_' not in line:
         clean_inventory += line+'\n'
-inv = yaml.safe_load(clean_inventory)
+inv = from_yaml(clean_inventory)
 
 try:
    ansible_config = subprocess.check_output(['ansible-config','dump']).decode('utf-8')

--- a/ansible-ssh
+++ b/ansible-ssh
@@ -1,4 +1,4 @@
-#!/Users/mkartson/ansible_venv/bin/python3
+#!/usr/bin/env python3
 import subprocess
 import sys
 import yaml


### PR DESCRIPTION
this fixes : 
```
 ansible-ssh -i inventory.yml dhcp-001

Traceback (most recent call last):
  File "/Users/mkartson/ansible_venv/bin/ansible-ssh", line 58, in <module>
    inv = yaml.safe_load(clean_inventory)
  File "/Users/mkartson/ansible_venv/lib/python3.10/site-packages/yaml/__init__.py", line 125, in safe_load
    return load(stream, SafeLoader)
  File "/Users/mkartson/ansible_venv/lib/python3.10/site-packages/yaml/__init__.py", line 81, in load
    return loader.get_single_data()
  File "/Users/mkartson/ansible_venv/lib/python3.10/site-packages/yaml/constructor.py", line 51, in get_single_data
    return self.construct_document(node)
  File "/Users/mkartson/ansible_venv/lib/python3.10/site-packages/yaml/constructor.py", line 60, in construct_document
    for dummy in generator:
  File "/Users/mkartson/ansible_venv/lib/python3.10/site-packages/yaml/constructor.py", line 413, in construct_yaml_map
    value = self.construct_mapping(node)
  File "/Users/mkartson/ansible_venv/lib/python3.10/site-packages/yaml/constructor.py", line 218, in construct_mapping
    return super().construct_mapping(node, deep=deep)
  File "/Users/mkartson/ansible_venv/lib/python3.10/site-packages/yaml/constructor.py", line 143, in construct_mapping
    value = self.construct_object(value_node, deep=deep)
  File "/Users/mkartson/ansible_venv/lib/python3.10/site-packages/yaml/constructor.py", line 100, in construct_object
    data = constructor(self, node)
  File "/Users/mkartson/ansible_venv/lib/python3.10/site-packages/yaml/constructor.py", line 427, in construct_undefined
    raise ConstructorError(None, None,
yaml.constructor.ConstructorError: could not determine a constructor for the tag '!vault'
  in "<unicode string>", line 115, column 28:
    github_gen_token: !vault |
                               ^
```