### PR TITLE
fallback os user and args.host if not specified

### DIFF
--- a/ansible-ssh
+++ b/ansible-ssh
@@ -1,94 +1,98 @@
 #!/usr/bin/env python3
+
+import os
 import subprocess
 import sys
-import yaml
-import os
 from ansible.parsing.utils.yaml import from_yaml
 from argparse import ArgumentParser
+import getpass  # For getting the OS user
 
+# Argument parsing
 parser = ArgumentParser()
-parser.add_argument("--inventory", '-i',help='ansible inventory file to use instead of the one defined in ansible.cfg')
-parser.add_argument("--key-file", '-k',dest="keyfile", help='ssh private key file to use instead of the default for the user')
-parser.add_argument("--user", '-u', '-l',dest="user", help='override the user defined in ansible inventory file')
-parser.add_argument("--verbose", '-v',action="store_true", dest="verbose", default=False,help='pass verbose flag to ssh command')
-parser.add_argument("--become", '-b',action="store_true", dest="become", default=False,help='ssh as root instead of the inventory-supplied account')
-parser.add_argument("host",nargs='?',help='the host to ssh into, if not provided a list of available hosts in current inventory file is printed')
+parser.add_argument("--inventory", '-i', help='Ansible inventory file to use instead of the one defined in ansible.cfg')
+parser.add_argument("--key-file", '-k', dest="keyfile", help='SSH private key file to use instead of the default for the user')
+parser.add_argument("--user", '-u', '-l', dest="user", help='Override the user defined in Ansible inventory file')
+parser.add_argument("--verbose", '-v', action="store_true", dest="verbose", default=False, help='Pass verbose flag to SSH command')
+parser.add_argument("--become", '-b', action="store_true", dest="become", default=False, help='SSH as root instead of the inventory-supplied account')
+parser.add_argument("host", nargs='?', help='The host to SSH into, if not provided, a list of available hosts in current inventory file is printed')
 args = parser.parse_args()
 
-clean_inventory = ansible_ssh_config_args = ssh_user = ''
-ansible_ssh_default_user = None
-ansible_ssh_default_keyfile = None
 inventory_args = []
 ssh_args = ['ssh']
+clean_inventory = ""
+ssh_user = None
 
 if args.inventory:
-    inventory_args += ['-i',args.inventory]
+    inventory_args += ['-i', args.inventory]
 
-if args.host is None:
-    print("You must specify one host to ssh into")
-    with open(os.devnull, 'w') as devnull:
-        hostlist = subprocess.check_output(['ansible','--list-hosts','all'] + inventory_args,stderr=devnull).decode('utf-8')
-        for line in hostlist.splitlines():
-            print(line)
-    sys.exit(-1)
+if not args.host:
+    print("You must specify one host to SSH into")
+    try:
+        hostlist = subprocess.check_output(['ansible', '--list-hosts', 'all'] + inventory_args).decode('utf-8')
+        print(hostlist)
+    except subprocess.CalledProcessError as e:
+        print(f"Error listing hosts: {e}")
+    sys.exit(1)
+
 host = args.host
+inventory_args += ['--yaml', '--host', host]
 
-inventory_args += ['--yaml','--host',host]
-
+# Add key file and verbosity to SSH arguments
 if args.keyfile:
-    ssh_args += ['-i',args.keyfile]
+    ssh_args += ['-i', args.keyfile]
 if args.verbose:
     ssh_args += ['-v']
 
-# initial try just to capture host missing cases
+# Fetch inventory data
 try:
-   inventory = subprocess.check_output(['ansible-inventory'] + inventory_args,stderr=subprocess.STDOUT).decode('utf-8')
+    inventory = subprocess.check_output(['ansible-inventory'] + inventory_args).decode('utf-8')
 except subprocess.CalledProcessError as e:
-   for line in e.output.splitlines():
-      if 'Could not match supplied host pattern' in line.decode('utf-8'):
-         print(line.decode('utf-8').lstrip())
-      if 'You must pass a single valid host' in line.decode('utf-8'):
-         print(line.decode('utf-8').lstrip())
-   sys.exit(-1)
+    print(f"Error fetching inventory: {e.output.decode('utf-8')}")
+    sys.exit(1)
 
-with open(os.devnull, 'w') as devnull:
-    inventory = subprocess.check_output(['ansible-inventory'] + inventory_args,stderr=devnull).decode('utf-8')
 for line in inventory.splitlines():
-    if 'WARNING' not in line and 'deprecation_' not in line:
-        clean_inventory += line+'\n'
+    if not line.startswith("WARNING") and not line.startswith("deprecation_"):
+        clean_inventory += line + '\n'
+
+# Parse inventory
 inv = from_yaml(clean_inventory)
 
-try:
-   ansible_config = subprocess.check_output(['ansible-config','dump']).decode('utf-8')
-except subprocess.CalledProcessError as e:
-   print(e)
-   sys.exit(-1)
-
-for line in ansible_config.splitlines():
-    if 'ANSIBLE_SSH_ARGS' in line:
-        ansible_ssh_config_args = line.split(' = ')[1]
-    elif 'DEFAULT_REMOTE_USER' in line:
-        ansible_ssh_default_user = line.split(' = ')[1]
-    elif 'DEFAULT_PRIVATE_KEY_FILE' in line and not line.endswith('None'):
-        ansible_ssh_default_keyfile = line.split(' = ')[1]
-ssh_args += [ansible_ssh_config_args]
-
-if 'ansible_ssh_common_args' in inv:
-    ssh_args += [inv['ansible_ssh_common_args']]
-if 'ansible_ssh_extra_args' in inv:
-    ssh_args += [inv['ansible_ssh_extra_args']]
-if ansible_ssh_default_user:
-    ssh_user = ansible_ssh_default_user
+# Determine SSH user
 if 'ansible_user' in inv:
     ssh_user = inv['ansible_user']
 if args.user:
     ssh_user = args.user
-if args.become:
+elif args.become:
     ssh_user = 'root'
-if ansible_ssh_default_keyfile:
-    ssh_args += ['-i',ansible_ssh_default_keyfile]
-ssh_args += ['-l',ssh_user,inv['ansible_host']]
+else:
+    # Fallback to OS user if not specified
+    try:
+        ssh_user = os.getlogin()
+    except OSError:
+        ssh_user = getpass.getuser()  # Fallback for non-interactive shells
 
+# Default SSH key file
+try:
+    ansible_config = subprocess.check_output(['ansible-config', 'dump']).decode('utf-8')
+    for line in ansible_config.splitlines():
+        if 'DEFAULT_PRIVATE_KEY_FILE' in line and not line.endswith('None'):
+            ssh_args += ['-i', line.split(' = ')[1]]
+except subprocess.CalledProcessError as e:
+    print(f"Error fetching Ansible config: {e}")
+    sys.exit(1)
+
+# Set host and user
+if ssh_user:
+    ssh_args += ['-l', ssh_user]
+
+if 'ansible_host' in inv:
+    ssh_host = inv['ansible_host']
+else:
+    ssh_host = host  # Use the host name if ansible_host is not defined
+
+ssh_args.append(ssh_host)
+
+# Execute SSH command
 command = ' '.join(ssh_args)
-print ("executing {}".format(command))
-os.system("{}".format(command))
+print(f"Executing: {command}")
+os.system(command)


### PR DESCRIPTION
Fix: Ansbile inventory not always include "ansible_host" if there are DNS names available
Fix: Fallback to os user for ssh if not specified elsewhere with "-u" or in the inventory
Some elegant GPT refactoring